### PR TITLE
Update Locations.json to fix Mining Guild

### DIFF
--- a/src/main/resources/Locations.json
+++ b/src/main/resources/Locations.json
@@ -214,7 +214,7 @@
   "Meiyerditch Laboratories": [[55,153], [55,152], [56,152]],
   "Menaphos": [[50,43]],
   "Mind Altar": [[43,75]],
-  "Mining Guild": [[47,151]],
+  "Mining Guild": [[46,151], [47,151]],
   "Miscellania": [[39,60]],
   "Mistrock": [[21,44]],
   "Molch": [[20,57]],


### PR DESCRIPTION
Expand Mining Guild coords to include western section of Elite Diary Amethyst Cave